### PR TITLE
fix: COOKIE_SECURE et JWT HttpOnly

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
+    env:
+      COOKIE_SECURE: "false"
 
     services:
       postgres:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -60,8 +60,9 @@ jobs:
       - name: ⚙️ Préparer l'environnement Symfony
         env:
           APP_ENV: test
-          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"  
+          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"
           MESSENGER_TRANSPORT_DSN: "sync://"
+          COOKIE_SECURE: "false"
         run: |
           touch .env
           php bin/console cache:clear
@@ -79,6 +80,7 @@ jobs:
           APP_ENV: test
           DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"
           MESSENGER_TRANSPORT_DSN: "sync://"
+          COOKIE_SECURE: "false"
         run: |
           php bin/console doctrine:database:create --if-not-exists
           php bin/console doctrine:schema:create
@@ -88,8 +90,9 @@ jobs:
       - name: 🧩 Vérifier le schéma Doctrine
         env:
           APP_ENV: test
-          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8" 
+          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"
           MESSENGER_TRANSPORT_DSN: "sync://"
+          COOKIE_SECURE: "false"
         run: php bin/console doctrine:schema:validate --skip-sync
 
       - name: 🧪 Lancer les tests PHPUnit

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -96,14 +96,16 @@ jobs:
         env:
           APP_ENV: test
           APP_SECRET: "ci_secret"
-          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"  # ✅ PostgreSQL
+          DATABASE_URL: "postgresql://follow_user:root@127.0.0.1:5432/followup_test?serverVersion=16&charset=utf8"
           JWT_PASSPHRASE: ""
           MAILER_DSN: "null://null"
           MESSENGER_TRANSPORT_DSN: "sync://"
           CORS_ALLOW_ORIGIN: "*"
           FRONTEND_URL: "http://localhost:3000"
           COOKIE_SECURE: "false"
-        run: php bin/phpunit
+        run: |
+          php bin/console cache:clear --env=test
+          php bin/phpunit
 
       - name: 🔍 Analyse statique PHPStan
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=512M

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -102,6 +102,7 @@ jobs:
           MESSENGER_TRANSPORT_DSN: "sync://"
           CORS_ALLOW_ORIGIN: "*"
           FRONTEND_URL: "http://localhost:3000"
+          COOKIE_SECURE: "false"
         run: php bin/phpunit
 
       - name: 🔍 Analyse statique PHPStan

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/doctrine-bundle": "^2.16",
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^3.5",
+        "gesdinet/jwt-refresh-token-bundle": "^2.0",
         "google/apiclient": "*",
         "lexik/jwt-authentication-bundle": "^3.1",
         "nelmio/api-doc-bundle": "^5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0bcf11e2a9e99a5e255ba8f7ad0e92b",
+    "content-hash": "5dc94b6b9a016b4cc488356a3827d7d3",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2577,6 +2577,84 @@
                 "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
             },
             "time": "2025-04-09T20:32:01+00:00"
+        },
+        {
+            "name": "gesdinet/jwt-refresh-token-bundle",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markitosgv/JWTRefreshTokenBundle.git",
+                "reference": "453bf7338025984e51918f65fcc0ca50645a168c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markitosgv/JWTRefreshTokenBundle/zipball/453bf7338025984e51918f65fcc0ca50645a168c",
+                "reference": "453bf7338025984e51918f65fcc0ca50645a168c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "lexik/jwt-authentication-bundle": "^2.15 || ^3.0",
+                "php": ">=8.2 || ^8.3 || ^8.4",
+                "symfony/config": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/console": "^6.4 || ^7.2 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0 || ^4.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/http-foundation": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/property-access": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/security-bundle": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/security-core": "^6.4 || ^7.0  || ^7.2 || ^8.0",
+                "symfony/security-http": "^6.4 || ^7.2 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/mongodb-odm": "<2.7",
+                "doctrine/orm": "<2.20"
+            },
+            "require-dev": {
+                "doctrine/mongodb-odm": "^2.7",
+                "doctrine/orm": "^2.20 || ^3.0",
+                "ergebnis/composer-normalize": "*",
+                "matthiasnoback/symfony-config-test": "^5.1 || ^6.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^5.1 || ^6.0",
+                "mongodb/mongodb": "^2.1",
+                "phpunit/phpunit": "^10.5 || ^12.2",
+                "rector/jack": "^0.5.0",
+                "rector/rector": "^2.2",
+                "symfony/cache": "^6.4 || ^7.2 || ^8.0",
+                "vimeo/psalm": "^7.0@beta"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Gesdinet\\JWTRefreshTokenBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcos Gómez Vilches",
+                    "email": "marcos@gesdinet.com"
+                }
+            ],
+            "description": "Implements a refresh token system over Json Web Tokens in Symfony",
+            "keywords": [
+                "jwt refresh token bundle symfony json web"
+            ],
+            "support": {
+                "issues": "https://github.com/markitosgv/JWTRefreshTokenBundle/issues",
+                "source": "https://github.com/markitosgv/JWTRefreshTokenBundle/tree/v2.0.0"
+            },
+            "time": "2025-12-29T23:20:41+00:00"
         },
         {
             "name": "google/apiclient",
@@ -13566,7 +13644,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -13574,6 +13652,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,4 +18,5 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
+    Gesdinet\JWTRefreshTokenBundle\GesdinetJWTRefreshTokenBundle::class => ['all' => true],
 ];

--- a/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -1,0 +1,9 @@
+gesdinet_jwt_refresh_token:
+    refresh_token_class: App\Entity\RefreshToken
+    ttl: 604800
+    ttl_update: true
+    cookie:
+        enabled: true
+        same_site: lax
+        http_only: true
+        secure: '%env(bool:COOKIE_SECURE)%'

--- a/config/packages/lexik_jwt_authentication.yaml
+++ b/config/packages/lexik_jwt_authentication.yaml
@@ -2,4 +2,10 @@ lexik_jwt_authentication:
     secret_key: '%kernel.project_dir%/config/jwt/private.pem'
     public_key: '%kernel.project_dir%/config/jwt/public.pem'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
-    token_ttl: 3600
+    token_ttl: 900
+    token_extractors:
+        cookie:
+            enabled: true
+            name: access_token
+        authorization_header:
+            enabled: false

--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -5,8 +5,11 @@ nelmio_cors:
         origin_regex: true
         allow_origin: ['%env(CORS_ALLOW_ORIGIN)%'] # liste des site autorisés à communiquer avec ce back
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE'] # liste les types de requêtes autorisées
-        allow_headers: ['Content-Type', 'Authorization'] # liste des en-tête authorisées à être envoyées depuis angular : Content-type: permet envoie json // Authorization : permet envoie token Jwt
+        allow_headers: ['Content-Type'] # Authorization retiré : le token passe maintenant en cookie HttpOnly
+        allow_credentials: true # Indispensable pour que les cookies soient envoyés sur les requêtes cross-origin
         expose_headers: ['Link']
         max_age: 3600 # Durée de validité du OK cors pour éviter au nav de redemander l'autorisation à chauqe appel
     paths: # Précise où appliquer les règles
         '^/api/': ~
+        '^/auth/': ~
+        '^/google/': ~

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -61,9 +61,17 @@ security:
                 check_path: /api/login_check
                 username_path: email
                 password_path: password
-                success_handler: lexik_jwt_authentication.handler.authentication_success
+                success_handler: App\Security\AuthenticationSuccessHandler
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
+
+        # ----------------------------
+        # 🔄 REFRESH TOKEN
+        # ----------------------------
+        refresh:
+            pattern: ^/api/token/refresh
+            stateless: true
+            security: false
 
         # ----------------------------
         # 🔐 FIREWALL PRINCIPAL API
@@ -96,6 +104,9 @@ security:
         # 🔓 PUBLIC : mot de passe oublié / reset
         - { path: ^/api/password/request, roles: PUBLIC_ACCESS }
         - { path: ^/api/password/reset, roles: PUBLIC_ACCESS }
+
+        # 🔓 PUBLIC : refresh token
+        - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
 
         # 🔓 PUBLIC : OAuth Google
         - { path: ^/auth/google, roles: PUBLIC_ACCESS }

--- a/config/routes/gesdinet_jwt_refresh_token.yaml
+++ b/config/routes/gesdinet_jwt_refresh_token.yaml
@@ -1,0 +1,2 @@
+gesdinet_jwt_refresh_token:
+    path: /api/token/refresh

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,6 +44,15 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
+    App\Controller\Auth\AuthController:
+        arguments:
+            $cookieSecure: '%env(bool:COOKIE_SECURE)%'
+
+    App\Security\AuthenticationSuccessHandler:
+        arguments:
+            $cookieSecure: '%env(bool:COOKIE_SECURE)%'
+            $refreshTokenTtl: 604800
+
     App\Service\AdzunaService:
         arguments:
             $httpClient: '@http_client'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,7 @@
 
 parameters:
     frontend_url: "%env(FRONTEND_URL)%"
+    env(COOKIE_SECURE): 'false'
 
 services:
     _defaults:

--- a/migrations/Version20260326203600.php
+++ b/migrations/Version20260326203600.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260326203600 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE refresh_tokens (id SERIAL NOT NULL, refresh_token VARCHAR(128) NOT NULL, username VARCHAR(255) NOT NULL, valid TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9BACE7E1C74F2195 ON refresh_tokens (refresh_token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP TABLE refresh_tokens');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,6 +46,9 @@
         <env name="JWT_PUBLIC_KEY" value="%kernel.project_dir%/config/jwt/public.pem"/>
         <env name="JWT_PASSPHRASE" value="mapassphrase"/>
 
+        <!-- Cookies HttpOnly — false en test (pas de HTTPS) -->
+        <env name="COOKIE_SECURE" value="false"/>
+
         <!-- Empêche l'envoi d'e-mails ou de notifications -->
         <env name="MAILER_DSN" value="null://localhost"/>
 

--- a/src/Controller/Api/LogoutController.php
+++ b/src/Controller/Api/LogoutController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Controller\Api;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class LogoutController extends AbstractController
+{
+    #[Route('/api/logout', name: 'api_logout', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function logout(): JsonResponse
+    {
+        $response = new JsonResponse(['message' => 'Déconnexion réussie.'], Response::HTTP_OK);
+
+        $response->headers->setCookie(Cookie::create('access_token')
+            ->withValue('')
+            ->withExpires(new \DateTimeImmutable('2000-01-01'))
+            ->withHttpOnly(true)
+            ->withPath('/')
+        );
+
+        $response->headers->setCookie(Cookie::create('refresh_token')
+            ->withValue('')
+            ->withExpires(new \DateTimeImmutable('2000-01-01'))
+            ->withHttpOnly(true)
+            ->withPath('/')
+        );
+
+        return $response;
+    }
+}

--- a/src/Controller/Auth/AuthController.php
+++ b/src/Controller/Auth/AuthController.php
@@ -4,10 +4,13 @@ namespace App\Controller\Auth;
 
 use App\Service\OAuthUserService;
 use App\Service\GoogleAuthService;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -21,32 +24,28 @@ use Symfony\Component\Routing\Annotation\Route;
  * 1. Frontend appelle `/auth/google` → redirection vers Google
  * 2. Google redirige sur `/google/callback?code=...`
  * 3. Le callback échange le code → récupère le profil Google → crée/récupère le User
- * 4. Un JWT FollowUp est généré et transmis au frontend via une redirection
+ * 4. Les cookies HttpOnly access_token + refresh_token sont posés, puis redirection vers le frontend
  */
 class AuthController extends AbstractController
 {
+    public function __construct(
+        private bool $cookieSecure,
+        private RefreshTokenGeneratorInterface $refreshTokenGenerator,
+        private RefreshTokenManagerInterface $refreshTokenManager,
+    ) {}
+
     /**
-     * Initie le flux OAuth Google en redirigeant l'utilisateur vers la page de consentement.
-     *
      * GET /auth/google
      */
     #[Route('/auth/google', name: 'auth_google')]
     public function google(GoogleAuthService $googleAuthService): RedirectResponse
     {
-        $client = $googleAuthService->getClient();
-        $authUrl = $client->createAuthUrl();
-
+        $authUrl = $googleAuthService->getClient()->createAuthUrl();
         return $this->redirect($authUrl);
     }
 
     /**
-     * Reçoit le callback Google OAuth, crée ou met à jour le compte utilisateur,
-     * génère un JWT FollowUp et redirige le frontend avec le token dans l'URL.
-     *
      * GET /google/callback?code=...
-     *
-     * En cas d'erreur (code manquant, token invalide, compte supprimé),
-     * redirige vers `/login?error={raison}`.
      */
     #[Route('/google/callback', name: 'auth_google_callback')]
     public function googleCallback(
@@ -56,38 +55,57 @@ class AuthController extends AbstractController
         JWTTokenManagerInterface $jwtManager
     ): RedirectResponse {
         $frontendUrl = $this->getParameter('frontend_url');
-
         $client = $googleAuthService->getClient();
         $code = $request->query->get('code');
 
         if (!$code) {
             return $this->redirect($frontendUrl . '/login?error=no_code');
         }
-        
+
         $token = $client->fetchAccessTokenWithAuthCode($code);
 
-
         if (isset($token['error'])) {
-          
             return $this->redirect($frontendUrl . '/login?error=token');
         }
 
         $oauth = new \Google\Service\Oauth2($client);
         $googleUser = $oauth->userinfo->get();
 
-        $email = $googleUser->email;
-        $firstName = $googleUser->givenName;
-        $lastName = $googleUser->familyName;
-        $googleId = $googleUser->id;
-
         try {
-            $user = $oauthUserService->getOrCreateFromGoogle($email, $firstName, $lastName, $googleId);
+            $user = $oauthUserService->getOrCreateFromGoogle(
+                $googleUser->email,
+                $googleUser->givenName,
+                $googleUser->familyName,
+                $googleUser->id
+            );
         } catch (\RuntimeException $e) {
             return $this->redirect($frontendUrl . '/google/callback?error=account_deleted');
         }
 
         $jwt = $jwtManager->create($user);
 
-        return $this->redirect($frontendUrl . '/google/callback?token=' . urlencode($jwt));
+        $refreshToken = $this->refreshTokenGenerator->createForUserWithTtl($user, 604800);
+        $this->refreshTokenManager->save($refreshToken);
+
+        $response = new RedirectResponse($frontendUrl . '/google/callback');
+
+        $response->headers->setCookie(Cookie::create('access_token')
+            ->withValue($jwt)
+            ->withHttpOnly(true)
+            ->withSecure($this->cookieSecure)
+            ->withSameSite('lax')
+            ->withPath('/')
+        );
+
+        $response->headers->setCookie(Cookie::create('refresh_token')
+            ->withValue($refreshToken->getRefreshToken())
+            ->withHttpOnly(true)
+            ->withSecure($this->cookieSecure)
+            ->withSameSite('lax')
+            ->withPath('/')
+            ->withExpires(new \DateTimeImmutable('+7 days'))
+        );
+
+        return $response;
     }
 }

--- a/src/Entity/RefreshToken.php
+++ b/src/Entity/RefreshToken.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'refresh_tokens')]
+class RefreshToken extends BaseRefreshToken
+{
+}

--- a/src/Security/AuthenticationSuccessHandler.php
+++ b/src/Security/AuthenticationSuccessHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Security;
+
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessResponse;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    public function __construct(
+        private JWTTokenManagerInterface $jwtManager,
+        private EventDispatcherInterface $dispatcher,
+        private RefreshTokenGeneratorInterface $refreshTokenGenerator,
+        private RefreshTokenManagerInterface $refreshTokenManager,
+        private bool $cookieSecure,
+        private int $refreshTokenTtl = 604800,
+    ) {}
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
+    {
+        $user = $token->getUser();
+        $jwt = $this->jwtManager->create($user);
+
+        $event = new AuthenticationSuccessEvent(['token' => $jwt], $user, new JWTAuthenticationSuccessResponse($jwt));
+        $this->dispatcher->dispatch($event, Events::AUTHENTICATION_SUCCESS);
+
+        $refreshToken = $this->refreshTokenGenerator->createForUserWithTtl($user, $this->refreshTokenTtl);
+        $this->refreshTokenManager->save($refreshToken);
+
+        $response = new JWTAuthenticationSuccessResponse($jwt);
+        $response->setData(['authenticated' => true]);
+
+        $response->headers->setCookie(Cookie::create('access_token')
+            ->withValue($jwt)
+            ->withHttpOnly(true)
+            ->withSecure($this->cookieSecure)
+            ->withSameSite('lax')
+            ->withPath('/')
+        );
+
+        $response->headers->setCookie(Cookie::create('refresh_token')
+            ->withValue($refreshToken->getRefreshToken())
+            ->withHttpOnly(true)
+            ->withSecure($this->cookieSecure)
+            ->withSameSite('lax')
+            ->withPath('/')
+            ->withExpires(new \DateTimeImmutable('+7 days'))
+        );
+
+        return $response;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -61,6 +61,20 @@
             "./migrations/.gitignore"
         ]
     },
+    "gesdinet/jwt-refresh-token-bundle": {
+        "version": "2.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "2390b4ed5c195e0b3f6dea45221f3b7c0af523a0"
+        },
+        "files": [
+            "config/packages/gesdinet_jwt_refresh_token.yaml",
+            "config/routes/gesdinet_jwt_refresh_token.yaml",
+            "src/Entity/RefreshToken.php"
+        ]
+    },
     "google/apiclient": {
         "version": "2.18",
         "recipe": {

--- a/tests/Api/AuthApiTest.php
+++ b/tests/Api/AuthApiTest.php
@@ -8,111 +8,178 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-/**
- * 🎓 TEST D'INTÉGRATION : Authentification JWT
- * 
- * Version simplifiée : Utilise des emails uniques pour éviter les conflits
- */
 class AuthApiTest extends WebTestCase
 {
     use DatabasePrimer;
 
-    /**
-     * 🧪 TEST #1 : Connexion réussie avec des identifiants valides
-     */
+    private function createVerifiedUser(string $email, string $plainPassword): User
+    {
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setPassword($hasher->hashPassword($user, $plainPassword));
+        $user->setIsVerified(true);
+        $user->setRoles(['ROLE_USER']);
+
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        return $user;
+    }
+
     public function test_login_with_valid_credentials_should_return_jwt_token(): void
     {
         $client = static::createClient();
-        $entityManager = static::getContainer()->get('doctrine')->getManager();
-        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
-        
-        // Utiliser un email unique pour ce test
-        $user = new User();
-        $user->setEmail('test1_' . uniqid() . '@gmail.com');
-        $user->setPassword($hasher->hashPassword($user, 'Password123'));
-        $user->setIsVerified(true);
-        $user->setRoles(['ROLE_USER']);
-        
-        $entityManager->persist($user);
-        $entityManager->flush();
-        
-        $loginData = [
+        $user = $this->createVerifiedUser('test1_' . uniqid() . '@gmail.com', 'Password123');
+
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
             'email' => $user->getEmail(),
-            'password' => 'Password123'
-        ];
-        
-        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($loginData));
-        
+            'password' => 'Password123',
+        ]));
+
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Le body doit retourner authenticated: true (plus de token en clair)
         $responseData = json_decode($client->getResponse()->getContent(), true);
-        $this->assertArrayHasKey('token', $responseData);
-        $this->assertIsString($responseData['token']);
-        $this->assertNotEmpty($responseData['token']);
-        
-        $tokenParts = explode('.', $responseData['token']);
-        $this->assertCount(3, $tokenParts);
+        $this->assertArrayHasKey('authenticated', $responseData);
+        $this->assertTrue($responseData['authenticated']);
+        $this->assertArrayNotHasKey('token', $responseData);
+
+        // Le cookie access_token HttpOnly doit être posé
+        $cookies = $client->getCookieJar()->all();
+        $accessTokenCookie = null;
+        foreach ($cookies as $cookie) {
+            if ($cookie->getName() === 'access_token') {
+                $accessTokenCookie = $cookie;
+                break;
+            }
+        }
+        $this->assertNotNull($accessTokenCookie, 'Le cookie access_token doit être présent');
+        $this->assertTrue($accessTokenCookie->isHttpOnly(), 'Le cookie access_token doit être HttpOnly');
+
+        // Le cookie doit contenir un JWT valide (3 parties séparées par des points)
+        $tokenParts = explode('.', $accessTokenCookie->getValue());
+        $this->assertCount(3, $tokenParts, 'Le cookie access_token doit contenir un JWT valide');
+
+        // Le cookie refresh_token doit aussi être posé
+        $refreshTokenCookie = null;
+        foreach ($cookies as $cookie) {
+            if ($cookie->getName() === 'refresh_token') {
+                $refreshTokenCookie = $cookie;
+                break;
+            }
+        }
+        $this->assertNotNull($refreshTokenCookie, 'Le cookie refresh_token doit être présent');
+        $this->assertTrue($refreshTokenCookie->isHttpOnly(), 'Le cookie refresh_token doit être HttpOnly');
     }
 
-    /**
-     * 🧪 TEST #2 : Connexion échoue avec un mot de passe incorrect
-     */
     public function test_login_with_invalid_password_should_return_401_unauthorized(): void
     {
         $client = static::createClient();
-        $entityManager = static::getContainer()->get('doctrine')->getManager();
-        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
-        
-        $user = new User();
-        $user->setEmail('test2_' . uniqid() . '@gmail.com');
-        $user->setPassword($hasher->hashPassword($user, 'CorrectPassword123'));
-        $user->setIsVerified(true);
-        $user->setRoles(['ROLE_USER']);
-        
-        $entityManager->persist($user);
-        $entityManager->flush();
-        
-        $loginData = [
+        $user = $this->createVerifiedUser('test2_' . uniqid() . '@gmail.com', 'CorrectPassword123');
+
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
             'email' => $user->getEmail(),
-            'password' => 'WrongPassword456'
-        ];
-        
-        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($loginData));
-        
+            'password' => 'WrongPassword456',
+        ]));
+
         $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
     }
 
-    /**
-     * 🧪 TEST #3 : Connexion échoue si l'utilisateur n'existe pas
-     */
     public function test_login_with_non_existent_user_should_return_401_unauthorized(): void
     {
         $client = static::createClient();
-        
-        $loginData = [
+
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
             'email' => 'nonexistent_' . uniqid() . '@gmail.com',
-            'password' => 'Password123'
-        ];
-        
-        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($loginData));
-        
+            'password' => 'Password123',
+        ]));
+
         $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
     }
 
-    /**
-     * 🧪 TEST #4 : Connexion échoue si les données sont manquantes
-     */
     public function test_login_with_missing_credentials_should_return_400_bad_request(): void
     {
         $client = static::createClient();
-        
-        // Test sans email
-        $dataWithoutEmail = ['password' => 'Password123'];
-        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($dataWithoutEmail));
+
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['password' => 'Password123']));
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
-        
-        // Test sans password
-        $dataWithoutPassword = ['email' => 'test@gmail.com'];
-        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($dataWithoutPassword));
+
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['email' => 'test@gmail.com']));
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function test_me_with_valid_cookie_should_return_user(): void
+    {
+        $client = static::createClient();
+        $user = $this->createVerifiedUser('test3_' . uniqid() . '@gmail.com', 'Password123');
+
+        // Login pour récupérer le cookie
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
+            'email' => $user->getEmail(),
+            'password' => 'Password123',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Le cookie est automatiquement renvoyé par le client de test
+        $client->request('GET', '/api/me');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $responseData = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($responseData['authenticated']);
+    }
+
+    public function test_me_without_cookie_should_return_401(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/api/me');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_me_with_authorization_header_should_return_401(): void
+    {
+        $client = static::createClient();
+        $user = $this->createVerifiedUser('test4_' . uniqid() . '@gmail.com', 'Password123');
+
+        // Générer un JWT manuellement via le service
+        $jwtManager = static::getContainer()->get('lexik_jwt_authentication.jwt_manager');
+        $token = $jwtManager->create($user);
+
+        // Tenter d'utiliser le header Authorization (doit échouer — désactivé)
+        $client->request('GET', '/api/me', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $token,
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_logout_should_expire_cookies(): void
+    {
+        $client = static::createClient();
+        $user = $this->createVerifiedUser('test5_' . uniqid() . '@gmail.com', 'Password123');
+
+        // Login
+        $client->request('POST', '/api/login_check', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
+            'email' => $user->getEmail(),
+            'password' => 'Password123',
+        ]));
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Logout
+        $client->request('POST', '/api/logout');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Vérifier que les cookies sont expirés dans la réponse
+        $setCookieHeaders = $client->getResponse()->headers->all('set-cookie');
+        $this->assertNotEmpty($setCookieHeaders, 'Des cookies doivent être modifiés lors du logout');
+
+        $cookieString = implode(' ', $setCookieHeaders);
+        $this->assertStringContainsString('access_token', $cookieString);
+        $this->assertStringContainsString('refresh_token', $cookieString);
     }
 }

--- a/tests/Api/CandidatureApiTest.php
+++ b/tests/Api/CandidatureApiTest.php
@@ -79,8 +79,8 @@ class CandidatureApiTest extends WebTestCase
 
         $token = $jwtManager->create($user);
 
+        $client->getCookieJar()->set(new \Symfony\Component\BrowserKit\Cookie('access_token', $token));
         $client->request('GET', '/api/my-candidatures', [], [], [
-            'HTTP_AUTHORIZATION' => 'Bearer ' . $token,
             'CONTENT_TYPE' => 'application/json'
         ]);
 
@@ -165,9 +165,8 @@ class CandidatureApiTest extends WebTestCase
 
         $tokenA = $jwtManager->create($userA);
 
-        $client->request('GET', '/api/my-candidatures', [], [], [
-            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokenA
-        ]);
+        $client->getCookieJar()->set(new \Symfony\Component\BrowserKit\Cookie('access_token', $tokenA));
+        $client->request('GET', '/api/my-candidatures');
 
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $responseData = json_decode($client->getResponse()->getContent(), true);


### PR DESCRIPTION
- **localhost -> httpOnly + refresh token**
- ** test cookie httpOnly**
- **fix: ajout COOKIE_SECURE dans l'env CI**
- **fix: COOKIE_SECURE dans phpunit.xml.dist pour les tests**
- **fix: cache:clear avant phpunit en CI pour charger COOKIE_SECURE**
- **fix: COOKIE_SECURE dans tous les steps CI qui compilent le container**
- **fix: COOKIE_SECURE défini au niveau job CI et dans .env**
- **fix: valeur par défaut pour COOKIE_SECURE dans services.yaml**
